### PR TITLE
added bump map support

### DIFF
--- a/kontsuba/core/principled_brdf.h
+++ b/kontsuba/core/principled_brdf.h
@@ -88,6 +88,7 @@ struct PrincipledBRDF {
   BRDF_PARAM(clearcoat_gloss, Float, 0.0);
 
   std::optional<Texture> normalMap;
+  std::optional<Texture> bumpMap;
 
   bool twoSided;
   std::set<Texture> textures;
@@ -134,6 +135,7 @@ struct PrincipledBRDF {
     auto metallicTexture =      probeMaterialTexture(material, aiTextureType_METALNESS);
     auto roughnessTexture =     probeMaterialTexture(material, aiTextureType_DIFFUSE_ROUGHNESS);
     auto normalTexture =        probeMaterialTexture(material, aiTextureType_NORMALS);
+    auto bumpTexture =          probeMaterialTexture(material, aiTextureType_HEIGHT);
     auto displacementTexture =  probeMaterialTexture(material, aiTextureType_DISPLACEMENT);
     auto occlusionTexture =     probeMaterialTexture(material, aiTextureType_AMBIENT_OCCLUSION);
     auto emissiveTexture =      probeMaterialTexture(material, aiTextureType_EMISSIVE);
@@ -144,11 +146,13 @@ struct PrincipledBRDF {
     brdf.roughness.texture = roughnessTexture;
 	
     brdf.normalMap = normalTexture;
+    brdf.bumpMap = bumpTexture;
 
     insert_if(diffuseTexture, brdf.textures);
     insert_if(metallicTexture, brdf.textures);
     insert_if(roughnessTexture, brdf.textures);
     insert_if(normalTexture, brdf.textures);
+    insert_if(bumpTexture, brdf.textures);
     insert_if(displacementTexture, brdf.textures);
     insert_if(occlusionTexture, brdf.textures);
     insert_if(emissiveTexture, brdf.textures);
@@ -220,6 +224,27 @@ XMLElement* toXML(XMLDocument& doc, const PrincipledBRDF& brdf){
     
     auto filenameNode = texelement->InsertNewChildElement("string");
     std::string filename = "textures/" + fs::path(brdf.normalMap.value()).filename().string();
+    filenameNode->SetAttribute("name", "filename");
+    filenameNode->SetAttribute("value", filename.c_str());
+    
+    element->InsertEndChild(old);
+  }
+
+  if(brdf.bumpMap.has_value()){
+    auto old = element;
+    element = doc.NewElement("bsdf");
+    element->SetAttribute("type", "bumpmap");
+    
+    auto texelement = element->InsertNewChildElement("texture");
+    texelement->SetAttribute("name", "bumpmap");
+    texelement->SetAttribute("type", "bitmap");
+    
+    auto noTransformNode = texelement->InsertNewChildElement("boolean");
+    noTransformNode->SetAttribute("name", "raw");
+    noTransformNode->SetAttribute("value", "true");
+    
+    auto filenameNode = texelement->InsertNewChildElement("string");
+    std::string filename = "textures/" + fs::path(brdf.bumpMap.value()).filename().string();
     filenameNode->SetAttribute("name", "filename");
     filenameNode->SetAttribute("value", filename.c_str());
     


### PR DESCRIPTION
Mitsuba can load both a height/bump map AND a normal map, therefore I implemented this to be able to load both at the same time, should they both exist.
Plus I added `xmlBrdfMapWrapper` to keep `toXML` clear and easy to read.